### PR TITLE
Support SDK 19+

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId "com.commit451.inkpageindicatorsample"
-        minSdkVersion 21
+        minSdkVersion 19
         targetSdkVersion 23
         versionCode 1
         versionName "1.0"

--- a/inkpageindicator/build.gradle
+++ b/inkpageindicator/build.gradle
@@ -6,7 +6,7 @@ android {
     buildToolsVersion "23.0.2"
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 19
         targetSdkVersion 23
         versionCode 101
         versionName "1.0.1"

--- a/inkpageindicator/src/main/java/com/commit451/inkpageindicator/InkPageIndicator.java
+++ b/inkpageindicator/src/main/java/com/commit451/inkpageindicator/InkPageIndicator.java
@@ -27,7 +27,9 @@ import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.Path;
 import android.graphics.RectF;
+import android.support.v4.view.ViewCompat;
 import android.support.v4.view.ViewPager;
+import android.support.v4.view.animation.FastOutSlowInInterpolator;
 import android.util.AttributeSet;
 import android.view.View;
 import android.view.animation.Interpolator;
@@ -146,8 +148,7 @@ public class InkPageIndicator extends View implements ViewPager.OnPageChangeList
         unselectedPaint.setColor(unselectedColour);
         selectedPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
         selectedPaint.setColor(selectedColour);
-        interpolator = android.view.animation.AnimationUtils.loadInterpolator(context,
-                android.R.interpolator.fast_out_slow_in);
+        interpolator = new FastOutSlowInInterpolator();
 
         // create paths & rect now – reuse & rewind later
         combinedUnselectedPath = new Path();
@@ -599,7 +600,7 @@ public class InkPageIndicator extends View implements ViewPager.OnPageChangeList
                 // todo avoid autoboxing
                 selectedDotX = (Float) valueAnimator.getAnimatedValue();
                 retreatAnimation.startIfNecessary(selectedDotX);
-                postInvalidateOnAnimation();
+                ViewCompat.postInvalidateOnAnimation(InkPageIndicator.this);
             }
         });
         moveSelected.addListener(new AnimatorListenerAdapter() {
@@ -628,18 +629,18 @@ public class InkPageIndicator extends View implements ViewPager.OnPageChangeList
     private void setJoiningFraction(int leftDot, float fraction) {
         if (leftDot < joiningFractions.length) {
             joiningFractions[leftDot] = fraction;
-            postInvalidateOnAnimation();
+            ViewCompat.postInvalidateOnAnimation(this);
         }
     }
 
     private void clearJoiningFractions() {
         Arrays.fill(joiningFractions, 0f);
-        postInvalidateOnAnimation();
+        ViewCompat.postInvalidateOnAnimation(this);
     }
 
     private void setDotRevealFraction(int dot, float fraction) {
         dotRevealFractions[dot] = fraction;
-        postInvalidateOnAnimation();
+        ViewCompat.postInvalidateOnAnimation(this);
     }
 
     private void cancelJoiningAnimations() {
@@ -712,7 +713,7 @@ public class InkPageIndicator extends View implements ViewPager.OnPageChangeList
                     public void onAnimationUpdate(ValueAnimator valueAnimator) {
                         // todo avoid autoboxing
                         retreatingJoinX1 = (Float) valueAnimator.getAnimatedValue();
-                        postInvalidateOnAnimation();
+                        ViewCompat.postInvalidateOnAnimation(InkPageIndicator.this);
                         // start any reveal animations if we've passed them
                         for (PendingRevealAnimator pendingReveal : revealAnimations) {
                             pendingReveal.startIfNecessary(retreatingJoinX1);
@@ -732,7 +733,7 @@ public class InkPageIndicator extends View implements ViewPager.OnPageChangeList
                     public void onAnimationUpdate(ValueAnimator valueAnimator) {
                         // todo avoid autoboxing
                         retreatingJoinX2 = (Float) valueAnimator.getAnimatedValue();
-                        postInvalidateOnAnimation();
+                        ViewCompat.postInvalidateOnAnimation(InkPageIndicator.this);
                         // start any reveal animations if we've passed them
                         for (PendingRevealAnimator pendingReveal : revealAnimations) {
                             pendingReveal.startIfNecessary(retreatingJoinX2);
@@ -752,13 +753,13 @@ public class InkPageIndicator extends View implements ViewPager.OnPageChangeList
                     }
                     retreatingJoinX1 = initialX1;
                     retreatingJoinX2 = initialX2;
-                    postInvalidateOnAnimation();
+                    ViewCompat.postInvalidateOnAnimation(InkPageIndicator.this);
                 }
                 @Override
                 public void onAnimationEnd(Animator animation) {
                     retreatingJoinX1 = INVALID_FRACTION;
                     retreatingJoinX2 = INVALID_FRACTION;
-                    postInvalidateOnAnimation();
+                    ViewCompat.postInvalidateOnAnimation(InkPageIndicator.this);
                 }
             });
         }
@@ -789,7 +790,7 @@ public class InkPageIndicator extends View implements ViewPager.OnPageChangeList
                 @Override
                 public void onAnimationEnd(Animator animation) {
                     setDotRevealFraction(PendingRevealAnimator.this.dot, 0f);
-                    postInvalidateOnAnimation();
+                    ViewCompat.postInvalidateOnAnimation(InkPageIndicator.this);
                 }
             });
         }


### PR DESCRIPTION
Covers ~2/3 of android devices. `Path` is the tricky one, but I have a feeling that when backported vector drawables are released in the support libraries, it'll come with a CompatPath implementation as well.
